### PR TITLE
Start daemon in the foreground

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,9 +10,4 @@ electrum setconfig rpcpassword ${ELECTRUM_PASSWORD}
 electrum setconfig rpcport 7000
 
 # run application
-electrum daemon start
-
-# wait forever
-while true; do
-  tail -f /dev/null & wait ${!}
-done
+electrum daemon


### PR DESCRIPTION
- logs to stdout
- do not require tail /dev/null