### PR TITLE
`docker-compose up` and `docker build` work again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.6-alpine
 
 ARG BUILD_DATE
 ARG VCS_REF
-ARG VERSION
+ARG VERSION=3.1.1
 LABEL maintainer="oc@co.ru" \
 	org.label-schema.build-date=$BUILD_DATE \
 	org.label-schema.name="Electrum wallet" \


### PR DESCRIPTION
- `VERSION` in Dockerfile defaults to 3.1.1 if not specified