### PR TITLE
upgrade base image from python:3.7-alpine to python:3.9.1-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.9.1-alpine
 
 ARG BUILD_DATE
 ARG VCS_REF


### PR DESCRIPTION
upgrade base image from python:3.7-alpine to python:3.9.1-alpine.

Tested successfully and runs without any issues.
