### PR TITLE
feature: support regtest and simnet networks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ ENV ELECTRUM_VERSION $VERSION
 ENV ELECTRUM_USER electrum
 ENV ELECTRUM_PASSWORD electrumz		# XXX: CHANGE REQUIRED!
 ENV ELECTRUM_HOME /home/$ELECTRUM_USER
+ENV ELECTRUM_NETWORK mainnet
 
 RUN apk --update-cache add --virtual build-dependencies gcc musl-dev && \
 	adduser -D $ELECTRUM_USER && \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env sh
 set -ex
 
-# Testnet support
-if [ "$TESTNET" = true ]; then
+# Network switch
+if [ "$TESTNET" = true ] || [ "$ELECTRUM_NETWORK" = "testnet" ]; then
   FLAGS='--testnet'
+elif [ "$ELECTRUM_NETWORK" = "regtest" ]; then
+  FLAGS='--regtest'
+elif [ "$ELECTRUM_NETWORK" = "simnet" ]; then
+  FLAGS='--simnet'
 fi
+
 
 # Graceful shutdown
 trap 'pkill -TERM -P1; electrum daemon stop; exit 0' SIGTERM


### PR DESCRIPTION
adds the ability to specify the network electrum will run on.
this commit introduces a new environment variable ELECTRUM_NETWORK
that can hold "mainnet", "testnet", "regtest" or "simnet" as value,
while keeping support for the existing environment variable TESTNET.