### PR TITLE
feature: create wallet directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,13 @@ RUN adduser -D $ELECTRUM_USER && \
     rm -f Electrum-${ELECTRUM_VERSION}.tar.gz && \
     apk del build-dependencies
 
-RUN mkdir -p ${ELECTRUM_HOME}/.electrum/ /data && \
+RUN mkdir -p /data \
+	  ${ELECTRUM_HOME}/.electrum/wallets/ \
+	  ${ELECTRUM_HOME}/.electrum/testnet/wallets/ \
+	  ${ELECTRUM_HOME}/.electrum/regtest/wallets/ \
+	  ${ELECTRUM_HOME}/.electrum/simnet/wallets/ && \
 	ln -sf ${ELECTRUM_HOME}/.electrum/ /data && \
-	chown ${ELECTRUM_USER} ${ELECTRUM_HOME}/.electrum /data
+	chown -R ${ELECTRUM_USER} ${ELECTRUM_HOME}/.electrum /data
 
 USER $ELECTRUM_USER
 WORKDIR $ELECTRUM_HOME


### PR DESCRIPTION
adds the ability to easily copy wallet files in the container.
this is a precondition for a potentially implemented wallet auto-loading feature.

this is the easiest solution i could come up with, without running into file permission errors.
it will prepare the wallet directories for mainnet, testnet, regtest and simnet.
the owner of the `${ELECTRUM_HOME}/.electrum` directory is set to `${ELECTRUM_USER}` recursively.